### PR TITLE
Support Protobuf Editions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is also a [reference document](docs/types.md) showing the protobuf scalar 
 First, install the "protoc" binary somewhere in your PATH.  You can get it by
 following [these instructions](docs/installing-protoc.md).
 
-This project requires at least `protoc` version 3.12.0.
+This project requires at least `protoc` version 28.0.
 
 ## Building from HEAD
 

--- a/docs/installing-protoc.md
+++ b/docs/installing-protoc.md
@@ -23,8 +23,8 @@ but they may be useful for other language bindings/plugins.)
 
 - Alternately, run the following commands:
 
-      PROTOC_ZIP=protoc-3.14.0-osx-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-28.0-osx-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v28.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
@@ -32,10 +32,10 @@ but they may be useful for other language bindings/plugins.)
 ## Linux
 - Run the following commands:
 
-      PROTOC_ZIP=protoc-3.14.0-linux-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-28.0-linux-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v28.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
 
-- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip).
+- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v28.0/protoc-28.0-linux-x86_64.zip).

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -93,13 +93,14 @@ import GHC.SourceGen
 -- either from this or another file).
 type Env n = Map.Map Text (Definition n)
 
-data SyntaxType = Proto2 | Proto3
+data SyntaxType = Proto2 | Proto3 | Editions
     deriving (Show, Eq)
 
 fileSyntaxType :: FileDescriptorProto -> SyntaxType
 fileSyntaxType f = case f ^. #syntax of
     "proto2" -> Proto2
     "proto3" -> Proto3
+    "editions" -> Editions
     "" -> Proto2  -- The proto compiler doesn't set syntax for proto2 files.
     s -> error $ "Unknown syntax type " ++ show s
 

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -31,7 +31,7 @@ import Proto.Google.Protobuf.Compiler.Plugin
     , CodeGeneratorResponse
     , CodeGeneratorResponse'Feature(..)
     )
-import Proto.Google.Protobuf.Descriptor (FileDescriptorProto)
+import Proto.Google.Protobuf.Descriptor (FileDescriptorProto, Edition(..))
 import System.Environment (getProgName)
 import System.Exit (exitWith, ExitCode(..))
 import System.IO as IO
@@ -69,10 +69,14 @@ makeResponse dflags prog request = let
     header f = "{- This file was auto-generated from "
                 <> (f ^. #name)
                 <> " by the " <> pack prog <> " program. -}\n"
-    features = [CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL]
+    features = [ CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+               , CodeGeneratorResponse'FEATURE_SUPPORTS_EDITIONS
+               ]
     in defMessage
            & #supportedFeatures .~
                (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
+           & #minimumEdition .~ fromIntegral (fromEnum EDITION_2023)
+           & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
            & #file .~ [ defMessage
                             & #name .~ outputName
                             & #content .~ outputContent

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -56,6 +56,15 @@ tests:
       - Proto.Canonical
       - Proto.Canonical_Fields
 
+  editions2023_test:
+    main: editions2023_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.Editions2023
+      - Proto.Editions2023_Fields
+
   group_test:
     main: group_test.hs
     source-dirs: tests

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -226,6 +226,37 @@ test-suite descriptor_test
     , proto-lens
     , proto-lens-arbitrary
     , proto-lens-protobuf-types
+    , proto-lens-runtime
+    , proto-lens-tests
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+  default-language: Haskell2010
+
+test-suite editions2023_test
+  type: exitcode-stdio-1.0
+  main-is: editions2023_test.hs
+  other-modules:
+      Paths_proto_lens_tests
+      Proto.Editions2023
+      Proto.Editions2023_Fields
+  autogen-modules:
+      Paths_proto_lens_tests
+      Proto.Editions2023
+      Proto.Editions2023_Fields
+  hs-source-dirs:
+      tests
+  build-tool-depends:
+      proto-lens-protoc:proto-lens-protoc
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , lens-family
+    , pretty
+    , proto-lens
+    , proto-lens-arbitrary
     , proto-lens-runtime
     , proto-lens-tests
     , tasty

--- a/proto-lens-tests/tests/editions2023.proto
+++ b/proto-lens-tests/tests/editions2023.proto
@@ -1,0 +1,44 @@
+edition = "2023";
+
+// Features to preserve proto3 behavior.
+// See https://protobuf.dev/editions/features/#proto3-behavior.
+//
+// Eventually we want this to diverge from proto3.proto,
+// e.g., set features on individual fields,
+// but we use a test virtually identical to proto3_test.hs for now.
+option features.field_presence = IMPLICIT;
+option features.enum_type = OPEN;
+option features.json_format = ALLOW;
+option features.utf8_validation = VERIFY;
+
+package editions2023;
+
+message Foo {
+  int32 a = 1;
+  repeated string b = 2;
+  oneof bar {
+    float c = 3;
+    bytes d = 4;
+    Sub s = 8;
+  }
+
+  message Sub {
+    int32 e = 1;
+  }
+  Sub sub = 5;
+
+  enum FooEnum {
+    option allow_alias = true;
+    Enum1 = 0;
+    Enum2 = 3;
+    Enum2a = 3;
+  }
+  FooEnum enum = 6;
+
+  repeated int32 f = 7;
+}
+
+message Strings {
+  bytes bytes = 1;
+  string string = 2;
+}

--- a/proto-lens-tests/tests/editions2023_test.hs
+++ b/proto-lens-tests/tests/editions2023_test.hs
@@ -1,0 +1,139 @@
+-- Copyright 2024 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.ProtoLens
+import Lens.Family2 ((&), (.~), (^.))
+import qualified Data.ByteString.Builder as Builder
+import Proto.Editions2023
+    ( Foo
+    , Foo'FooEnum(..)
+    , Foo'Sub
+    , Strings
+    )
+import Proto.Editions2023_Fields
+    ( a
+    , b
+    , c
+    , d
+    , e
+    , f
+    , s
+    , sub
+    , maybe'c
+    , maybe'sub
+    , maybe's
+    , enum
+    , bytes
+    , string
+    )
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (testCase, (@=?), assertBool)
+
+import Data.ProtoLens.TestUtil
+
+main :: IO ()
+main = testMain
+  [ testGroup "Foo"
+    [ serializeTo "int32"
+        (defMessage & a .~ 150 :: Foo)
+        "a: 150"
+        $ tagged 1 $ VarInt 150
+    , serializeTo "repeated-string"
+        (defMessage & b .~ ["one", "two"] :: Foo)
+        (vcat $ map (keyedStr "b") ["one", "two"])
+        $ mconcat (map (tagged 2 . Lengthy) ["one", "two"])
+    , testGroup "oneof"
+        [ serializeTo "float"
+            -- Use denominators that aren't divisible by 2, to fill out the bits.
+            (defMessage & c .~ (20 / 3) :: Foo)
+            "c: 6.6666665"
+            $ tagged 3 $ Fixed32 0x40d55555
+        , serializeTo "bytes"
+            (defMessage & d .~ "a\0b" :: Foo)
+            "d: \"a\\000b\""
+            $ tagged 4 $ Lengthy "a\0b"
+        , serializeTo "overridden value"
+            (defMessage & d .~ "a\0b" & c .~ (20 / 3) :: Foo)
+            "c: 6.6666665"
+            $ tagged 3 $ Fixed32 0x40d55555
+        -- Scalar "oneof" fields should have a "maybe" selector.
+        , testCase "maybe" $ do
+            Nothing @=? (defMessage :: Foo) ^. maybe'c
+            Just 42 @=? ((defMessage :: Foo) & c .~ 42) ^. maybe'c
+            Nothing @=? (defMessage :: Foo) ^. maybe's
+        , testCase "message" $ do
+            Just 42 @=? ((defMessage :: Foo) & s .~ (defMessage :: Foo'Sub) & c .~ 42) ^. maybe'c
+            Nothing @=? ((defMessage :: Foo) & s .~ (defMessage :: Foo'Sub) & c .~ 42) ^. maybe's
+            17 @=? ((defMessage :: Foo) & s . e .~ 17) ^. s . e
+            let val = (defMessage :: Foo'Sub) & e .~ 17
+            Just val @=? ((defMessage :: Foo) & s .~ val) ^. maybe's
+        ]
+    -- Repeated scalar fields in proto3 should serialize as "packed" by default.
+    , serializeTo "packed-by-default"
+        (defMessage & f .~ [1,2,3] :: Foo)
+        (vcat [keyedInt "f" x | x <- [1..3]])
+        $ tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
+    , runTypedTest (roundTripTest "foo" :: TypedTest Foo)
+    ]
+  , testGroup "Strings"
+    [ deserializeFrom "bytes"
+        (Just $ defMessage & bytes .~ toStrictByteString invalidUtf8 :: Maybe Strings)
+        $ tagged 1 $ Lengthy invalidUtf8
+    , deserializeFrom "string"
+        (Nothing :: Maybe Strings)
+        $ tagged 2 $ Lengthy invalidUtf8
+    ]
+  -- Scalar field defaults are indistinguishable from unset fields.
+  , testGroup "defaulting"
+      [ testCase "int" $ (defMessage :: Foo) @=? (defMessage & a .~ 0)
+      , testCase "bytes" $ (defMessage :: Strings) @=? (defMessage & bytes .~ "")
+      , testCase "string" $ (defMessage :: Strings) @=? (defMessage & string .~ "")
+      , testCase "enum" $ (defMessage :: Foo) @=? (defMessage & enum .~ Foo'Enum1)
+      ]
+  -- Enums are sum types, except for aliases
+  , testGroup "enum"
+      [ testCase "aliases are exported" $ Foo'Enum2 @=? Foo'Enum2a
+      , serializeTo "serializeTo enum"
+          (defMessage & enum .~ Foo'Enum2 :: Foo)
+          "enum: Enum2"
+          $ tagged 6 $ VarInt 3
+      , serializeTo "serializeTo unrecognized"
+          (defMessage & enum .~ toEnum 9 :: Foo)
+          "enum: 9"
+          $ tagged 6 $ VarInt 9
+      , testCase "enum values" $ do
+          map toEnum [0, 3, 3] @=? [Foo'Enum1, Foo'Enum2, Foo'Enum2a]
+          fromEnum <$> (maybeToEnum 4 :: Maybe Foo'FooEnum) @=? Just 4
+          ["Foo'Enum1", "Foo'Enum2", "Foo'Enum2", "Foo'FooEnum'Unrecognized (Foo'FooEnum'UnrecognizedValue 5)"]
+              @=? map show [Foo'Enum1, Foo'Enum2, Foo'Enum2a, toEnum 5]
+          ["Enum1", "Enum2", "Enum2", "6"]
+              @=? map showEnum [Foo'Enum1, Foo'Enum2, Foo'Enum2a, toEnum 6]
+          [Just Foo'Enum1, Just Foo'Enum2, Just Foo'Enum2, maybeToEnum 4, maybeToEnum 5]
+              @=? map readEnum ["Enum1", "Enum2", "Enum2a", "4", "5"]
+      , testCase "enum patterns" $ do
+          assertBool "enum value" $ case toEnum 3 of
+                                      Foo'Enum2 -> True
+                                      _ -> False
+          assertBool "enum alias" $ case toEnum 3 of
+                                      Foo'Enum2a -> True
+                                      _ -> False
+
+      ]
+  -- Unset proto3 messages are different than the default value.
+  , testGroup "submessage"
+      [ testCase "Nothing" $ Nothing @=? ((defMessage :: Foo) ^. maybe'sub)
+      , testCase "Just" $ do
+          let val = (defMessage :: Foo'Sub) & e .~ 3
+          Just val @=? ((defMessage :: Foo) & sub .~ val) ^. maybe'sub
+      ]
+  ]
+
+
+invalidUtf8 :: Builder.Builder
+invalidUtf8 = Builder.word8 0xc3 <> Builder.word8 0x28


### PR DESCRIPTION
Current status is that it can process Protobuf Editions files.  However, it is not worthy of release yet, as it does not adjust semantics based on specified features yet.