### PR TITLE
Support Protobuf Editions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is also a [reference document](docs/types.md) showing the protobuf scalar 
 First, install the "protoc" binary somewhere in your PATH.  You can get it by
 following [these instructions](docs/installing-protoc.md).
 
-This project requires at least `protoc` version 3.12.0.
+This project requires at least `protoc` version 28.0.
 
 ## Building from HEAD
 

--- a/docs/installing-protoc.md
+++ b/docs/installing-protoc.md
@@ -23,8 +23,8 @@ but they may be useful for other language bindings/plugins.)
 
 - Alternately, run the following commands:
 
-      PROTOC_ZIP=protoc-3.14.0-osx-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-28.0-osx-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v28.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
@@ -32,10 +32,10 @@ but they may be useful for other language bindings/plugins.)
 ## Linux
 - Run the following commands:
 
-      PROTOC_ZIP=protoc-3.14.0-linux-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-28.0-linux-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v28.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
 
-- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip).
+- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v28.0/protoc-28.0-linux-x86_64.zip).

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -93,13 +93,14 @@ import GHC.SourceGen
 -- either from this or another file).
 type Env n = Map.Map Text (Definition n)
 
-data SyntaxType = Proto2 | Proto3
+data SyntaxType = Proto2 | Proto3 | Editions
     deriving (Show, Eq)
 
 fileSyntaxType :: FileDescriptorProto -> SyntaxType
 fileSyntaxType f = case f ^. #syntax of
     "proto2" -> Proto2
     "proto3" -> Proto3
+    "editions" -> Editions
     "" -> Proto2  -- The proto compiler doesn't set syntax for proto2 files.
     s -> error $ "Unknown syntax type " ++ show s
 

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -51,7 +51,10 @@ import Data.Maybe (catMaybes, fromMaybe)
 import Data.Monoid ((<>))
 #endif
 import Data.ProtoLens.Labels ()
-import Data.ProtoLens.Compiler.Editions.Features (featuresForEdition)
+import Data.ProtoLens.Compiler.Editions.Features
+    ( featuresForEdition
+    , mergedInto
+    )
 import qualified Data.Semigroup as Semigroup
 import qualified Data.Set as Set
 import Data.String (IsString(..))
@@ -119,9 +122,16 @@ fileEdition f = case f ^. #syntax of
   "" -> EDITION_PROTO2
   s -> error $ "Unknown syntax type " ++ show s
 
-{-| Returns the feature defaults for the file. -}
+{-| Returns the feature defaults for the file.
+
+This includes the file-scope options which override
+the feature defaults for an edition.
+-}
 fileFeatures :: FileDescriptorProto -> FeatureSet
-fileFeatures f = featuresForEdition $ fileEdition f
+fileFeatures f = case f ^. #options . #maybe'features of
+  Just overrides -> overrides `mergedInto` editionFeatures
+  Nothing -> editionFeatures
+  where editionFeatures = featuresForEdition $ fileEdition f
 
 data Definition n = Message (MessageInfo n) | Enum (EnumInfo n)
     deriving Functor
@@ -390,7 +400,7 @@ messageDefs features protoPrefix hsPrefix groups d
             , messageDescriptor = d
             , messageFields =
                   map (PlainFieldInfo <$>
-                              (fieldKind features mapEntries) <*> (fieldInfo hsPrefix'))
+                              (fieldKind features' mapEntries) <*> (fieldInfo hsPrefix'))
                       $ Map.findWithDefault [] Nothing allFields
             , messageOneofFields = collectOneofFields hsPrefix' d allFields
             , messageUnknownFields =
@@ -398,7 +408,7 @@ messageDefs features protoPrefix hsPrefix groups d
             , groupFieldNumber = Map.lookup protoName groups
             }
     subDefs = messageAndEnumDefs
-                    features
+                    features'
                     (protoName <> ".")
                     hsPrefix'
                     (collectGroupFields $ d ^. #field)
@@ -407,6 +417,10 @@ messageDefs features protoPrefix hsPrefix groups d
     -- For efficiency, only look for map entries within the immediate
     -- nested types, rather than recursively searching through all of them.
     mapEntries = collectMapEntries $ map rootLabel subDefs
+    -- Include message-scope feature overrides.
+    features' = case d ^. #options . #maybe'features of
+      Just overrides -> overrides `mergedInto ` features
+      Nothing -> features
 
 -- | If this type is a map entry, retrieves the relevant information
 -- along with the proto name of this type.
@@ -450,7 +464,7 @@ fieldKind ::
     -> FieldKind
 fieldKind features mapEntries f = case f ^. #label of
             FieldDescriptorProto'LABEL_OPTIONAL ->
-                case features ^. #fieldPresence of
+                case features' ^. #fieldPresence of
                   FeatureSet'IMPLICIT
                     | f ^. #type' /= FieldDescriptorProto'TYPE_MESSAGE
                       && not (f ^. #proto3Optional)
@@ -471,7 +485,7 @@ fieldKind features mapEntries f = case f ^. #label of
         | otherwise = Packable
 
     packedByDefault =
-        fromMaybe (features ^. #repeatedFieldEncoding == FeatureSet'PACKED)
+        fromMaybe (features' ^. #repeatedFieldEncoding == FeatureSet'PACKED)
         $ f ^. #options . #maybe'packed
 
     unpackableTypes =
@@ -480,6 +494,11 @@ fieldKind features mapEntries f = case f ^. #label of
         , FieldDescriptorProto'TYPE_STRING
         , FieldDescriptorProto'TYPE_BYTES
         ]
+
+    -- Include field-scope feature overrides
+    features' = case f ^. #options . #maybe'features of
+      Just overrides -> overrides `mergedInto` features
+      Nothing -> features
 
 collectOneofFields
     :: String -> DescriptorProto -> Map.Map (Maybe Int32) [FieldDescriptorProto]
@@ -634,10 +653,13 @@ enumDef features protoPrefix hsPrefix d = let
     mkHsName n = fromString $ hsPrefix ++ case hsName n of
       ('_':xs) -> 'X':xs
       xs       -> xs
+    features' = case d ^. #options . #maybe'features of
+      Just overrides -> overrides `mergedInto` features
+      Nothing -> features
     in (mkText (d ^. #name)
        , Enum EnumInfo
             { enumName = mkHsName (d ^. #name)
-            , enumUnrecognized = case features ^. #enumType of
+            , enumUnrecognized = case features' ^. #enumType of
                 FeatureSet'CLOSED -> Nothing
                 FeatureSet'OPEN ->
                   Just EnumUnrecognizedInfo

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
@@ -35,11 +35,11 @@ This contains the defaults from editions @LEGACY@ to @EDITION_2023@
 for the native features defined by @google.protobuf.FeatureSet@.
 The message was generated with @protoc@ and translated into a Haskell string:
 
-> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=LEGACY --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
+> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=PROTO2 --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
 > $ ghci
 > ghci> import Data.ByteString as B
 > ghci> B.readFile "defaults.binpb" >>= print . show
 
 -}
 serializedNativeDefaults :: ByteString
-serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\132\\a(\\232\\a\""
+serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\230\\a(\\232\\a\""

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
@@ -1,0 +1,44 @@
+-- Copyright 2024 Google LLC. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE OverloadedLabels #-}
+
+{-|
+Module: Data.ProtoLens.Compiler.Editions.Defaults
+Description: Exports defaults for native features in Protobuf Editions.
+Copyright: Copyright (c) 2024 Google LLC
+License: BSD3
+-}
+module Data.ProtoLens.Compiler.Editions.Defaults (defaults) where
+
+import Data.ByteString (ByteString)
+import Data.ProtoLens (decodeMessage)
+import Proto.Google.Protobuf.Descriptor (FeatureSetDefaults)
+
+{-| 'FeatureSetDefaults' message containing feature defaults.
+
+This contains the defaults from editions @LEGACY@ to @EDITION_2023@
+for the native features defined by @google.protobuf.FeatureSet@.
+-}
+defaults :: FeatureSetDefaults
+defaults | Right m <- msg = m
+         | Left e <- msg = error $ "unable to decode built-in defaults: " ++ e
+  where msg = decodeMessage serializedDefaults
+
+{-| Serialized 'FeatureSetDefaults' message containing feature defaults.
+
+This contains the defaults from editions @LEGACY@ to @EDITION_2023@
+for the native features defined by @google.protobuf.FeatureSet@.
+The message was generated with @protoc@ and translated into a Haskell string:
+
+> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=LEGACY --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
+> $ ghci
+> ghci> import Data.ByteString as B
+> ghci> B.readFile "defaults.binpb" >>= print . show
+
+-}
+serializedDefaults :: ByteString
+serializedDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\132\\a(\\232\\a\""

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
@@ -12,7 +12,7 @@ Description: Exports defaults for native features in Protobuf Editions.
 Copyright: Copyright (c) 2024 Google LLC
 License: BSD3
 -}
-module Data.ProtoLens.Compiler.Editions.Defaults (defaults) where
+module Data.ProtoLens.Compiler.Editions.Defaults (nativeDefaults) where
 
 import Data.ByteString (ByteString)
 import Data.ProtoLens (decodeMessage)
@@ -23,10 +23,11 @@ import Proto.Google.Protobuf.Descriptor (FeatureSetDefaults)
 This contains the defaults from editions @LEGACY@ to @EDITION_2023@
 for the native features defined by @google.protobuf.FeatureSet@.
 -}
-defaults :: FeatureSetDefaults
-defaults | Right m <- msg = m
-         | Left e <- msg = error $ "unable to decode built-in defaults: " ++ e
-  where msg = decodeMessage serializedDefaults
+nativeDefaults :: FeatureSetDefaults
+nativeDefaults
+  | Right m <- msg = m
+  | Left e <- msg = error $ "unable to decode built-in defaults: " ++ e
+  where msg = decodeMessage serializedNativeDefaults
 
 {-| Serialized 'FeatureSetDefaults' message containing feature defaults.
 
@@ -40,5 +41,5 @@ The message was generated with @protoc@ and translated into a Haskell string:
 > ghci> B.readFile "defaults.binpb" >>= print . show
 
 -}
-serializedDefaults :: ByteString
-serializedDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\132\\a(\\232\\a\""
+serializedNativeDefaults :: ByteString
+serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\132\\a(\\232\\a\""

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
@@ -48,7 +48,7 @@ for a particular edition.
 featuresForEditionFromDefaults :: FeatureSetDefaults -> Edition -> FeatureSet
 featuresForEditionFromDefaults defaults edition
   | (d : _) <- candidates = (d ^. #overridableFeatures) `mergedInto` (d ^. #fixedFeatures)
-  | otherwise = defMessage
+  | otherwise = error $ "Unsupported edition with tag number: " ++ show (fromEnum edition)
   where
     candidates = dropWhile (\d -> d ^. #edition > edition) recentFirst
 

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
@@ -1,0 +1,86 @@
+-- Copyright 2024 Google LLC. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE OverloadedLabels #-}
+
+{-|
+Module: Data.ProtoLens.Compiler.Editions.Features
+Description: Resolves a feature set for a particular edition with Protobuf Editions.
+Copyright: Copyright (c) 2024 Google LLC
+License: BSD3
+-}
+module Data.ProtoLens.Compiler.Editions.Features
+  ( featuresForEdition
+  , featuresForEditionFromDefaults
+  , mergedInto
+  ) where
+
+import Control.Applicative ((<|>))
+import Data.ProtoLens (defMessage)
+import Data.ProtoLens.Compiler.Editions.Defaults (nativeDefaults)
+import Data.ProtoLens.Labels ()
+import Lens.Family2 ((^.), (.~), (&))
+import Proto.Google.Protobuf.Descriptor
+  ( Edition
+  , FeatureSet
+  , FeatureSetDefaults)
+
+{-|
+Returns the native feature set defaults for the given edition.
+
+Native features refer to the fields directly defined by 'FeatureSet'.
+Features defined as extensions of 'FeatureSet' would be custom features.
+-}
+featuresForEdition :: Edition -> FeatureSet
+featuresForEdition = featuresForEditionFromDefaults nativeDefaults
+
+{-|
+Given the feature set defaults for multiple editions,
+return the feature set defaults for the given edition.
+
+If extensions were supported, this could be used directly
+to resolve custom features defined as extensions of 'FeatureSet'
+for a particular edition.
+-}
+featuresForEditionFromDefaults :: FeatureSetDefaults -> Edition -> FeatureSet
+featuresForEditionFromDefaults defaults edition
+  | (d : _) <- candidates = (d ^. #overridableFeatures) `mergedInto` (d ^. #fixedFeatures)
+  | otherwise = defMessage
+  where
+    candidates = dropWhile (\d -> d ^. #edition > edition) recentFirst
+
+    -- #defaults is supposed to be in ascending order of editions
+    recentFirst = reverse $ defaults ^. #defaults
+
+{-|
+Returns the result of merging a 'FeatureSet' message into another 'FeatureSet' message.
+
+The semantics are the same as @MergeFrom@ in C++.
+When merging a message A into a message B, then any field that has a value in A
+will override the value of the same field in B,
+otherwise the field in B is used as is.
+
+Consider using this function as an infix operator.
+For example,
+
+>>> let c = a `mergedInto` b
+
+could be read like "message C is the message A merged into message B".
+
+If merging was generally supported for all messages,
+we would use it directly instead of using this custom implementation for 'FeatureSet'.
+This does not support merging extensions or unknown fields.
+-}
+mergedInto :: FeatureSet  -- ^ Feature set to merge from.
+           -> FeatureSet  -- ^ Feature set to merge into.
+           -> FeatureSet  -- ^ The merged feature set.
+mergedInto a b = defMessage
+  & #maybe'fieldPresence .~ (a ^. #maybe'fieldPresence <|> b ^. #maybe'fieldPresence)
+  & #maybe'enumType .~ (a ^. #maybe'enumType <|> b ^. #maybe'enumType)
+  & #maybe'repeatedFieldEncoding .~ (a ^. #maybe'repeatedFieldEncoding <|> b ^. #maybe'repeatedFieldEncoding)
+  & #maybe'utf8Validation .~ (a ^. #maybe'utf8Validation <|> b ^. #maybe'utf8Validation)
+  & #maybe'messageEncoding .~ (a ^. #maybe'messageEncoding <|> b ^. #maybe'messageEncoding)
+  & #maybe'jsonFormat .~ (a ^. #maybe'jsonFormat <|> b ^. #maybe'jsonFormat)

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -31,7 +31,7 @@ import Proto.Google.Protobuf.Compiler.Plugin
     , CodeGeneratorResponse
     , CodeGeneratorResponse'Feature(..)
     )
-import Proto.Google.Protobuf.Descriptor (FileDescriptorProto)
+import Proto.Google.Protobuf.Descriptor (FileDescriptorProto, Edition(..))
 import System.Environment (getProgName)
 import System.Exit (exitWith, ExitCode(..))
 import System.IO as IO
@@ -69,10 +69,14 @@ makeResponse dflags prog request = let
     header f = "{- This file was auto-generated from "
                 <> (f ^. #name)
                 <> " by the " <> pack prog <> " program. -}\n"
-    features = [CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL]
+    features = [ CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+               , CodeGeneratorResponse'FEATURE_SUPPORTS_EDITIONS
+               ]
     in defMessage
            & #supportedFeatures .~
                (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
+           & #minimumEdition .~ fromIntegral (fromEnum EDITION_2023)
+           & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
            & #file .~ [ defMessage
                             & #name .~ outputName
                             & #content .~ outputContent

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -75,7 +75,7 @@ makeResponse dflags prog request = let
     in defMessage
            & #supportedFeatures .~
                (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
-           & #minimumEdition .~ fromIntegral (fromEnum EDITION_2023)
+           & #minimumEdition .~ fromIntegral (fromEnum EDITION_LEGACY)
            & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
            & #file .~ [ defMessage
                             & #name .~ outputName

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -75,7 +75,7 @@ makeResponse dflags prog request = let
     in defMessage
            & #supportedFeatures .~
                (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
-           & #minimumEdition .~ fromIntegral (fromEnum EDITION_LEGACY)
+           & #minimumEdition .~ fromIntegral (fromEnum EDITION_PROTO2)
            & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
            & #file .~ [ defMessage
                             & #name .~ outputName

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -42,6 +42,7 @@ executable proto-lens-protoc
   main-is: protoc-gen-haskell.hs
   other-modules:
       Data.ProtoLens.Compiler.Definitions
+      Data.ProtoLens.Compiler.Editions.Defaults
       Data.ProtoLens.Compiler.Generate
       Data.ProtoLens.Compiler.Generate.Commented
       Data.ProtoLens.Compiler.Generate.Encoding

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -43,6 +43,7 @@ executable proto-lens-protoc
   other-modules:
       Data.ProtoLens.Compiler.Definitions
       Data.ProtoLens.Compiler.Editions.Defaults
+      Data.ProtoLens.Compiler.Editions.Features
       Data.ProtoLens.Compiler.Generate
       Data.ProtoLens.Compiler.Generate.Commented
       Data.ProtoLens.Compiler.Generate.Encoding

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -56,6 +56,15 @@ tests:
       - Proto.Canonical
       - Proto.Canonical_Fields
 
+  editions2023_test:
+    main: editions2023_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.Editions2023
+      - Proto.Editions2023_Fields
+
   group_test:
     main: group_test.hs
     source-dirs: tests

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -226,6 +226,37 @@ test-suite descriptor_test
     , proto-lens
     , proto-lens-arbitrary
     , proto-lens-protobuf-types
+    , proto-lens-runtime
+    , proto-lens-tests
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+  default-language: Haskell2010
+
+test-suite editions2023_test
+  type: exitcode-stdio-1.0
+  main-is: editions2023_test.hs
+  other-modules:
+      Paths_proto_lens_tests
+      Proto.Editions2023
+      Proto.Editions2023_Fields
+  autogen-modules:
+      Paths_proto_lens_tests
+      Proto.Editions2023
+      Proto.Editions2023_Fields
+  hs-source-dirs:
+      tests
+  build-tool-depends:
+      proto-lens-protoc:proto-lens-protoc
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , lens-family
+    , pretty
+    , proto-lens
+    , proto-lens-arbitrary
     , proto-lens-runtime
     , proto-lens-tests
     , tasty

--- a/proto-lens-tests/tests/editions2023.proto
+++ b/proto-lens-tests/tests/editions2023.proto
@@ -1,0 +1,44 @@
+edition = "2023";
+
+// Features to preserve proto3 behavior.
+// See https://protobuf.dev/editions/features/#proto3-behavior.
+//
+// Eventually we want this to diverge from proto3.proto,
+// e.g., set features on individual fields,
+// but we use a test virtually identical to proto3_test.hs for now.
+option features.field_presence = IMPLICIT;
+option features.enum_type = OPEN;
+option features.json_format = ALLOW;
+option features.utf8_validation = VERIFY;
+
+package editions2023;
+
+message Foo {
+  int32 a = 1;
+  repeated string b = 2;
+  oneof bar {
+    float c = 3;
+    bytes d = 4;
+    Sub s = 8;
+  }
+
+  message Sub {
+    int32 e = 1;
+  }
+  Sub sub = 5;
+
+  enum FooEnum {
+    option allow_alias = true;
+    Enum1 = 0;
+    Enum2 = 3;
+    Enum2a = 3;
+  }
+  FooEnum enum = 6;
+
+  repeated int32 f = 7;
+}
+
+message Strings {
+  bytes bytes = 1;
+  string string = 2;
+}

--- a/proto-lens-tests/tests/editions2023.proto
+++ b/proto-lens-tests/tests/editions2023.proto
@@ -1,15 +1,9 @@
 edition = "2023";
 
-// Features to preserve proto3 behavior.
-// See https://protobuf.dev/editions/features/#proto3-behavior.
-//
-// Eventually we want this to diverge from proto3.proto,
-// e.g., set features on individual fields,
-// but we use a test virtually identical to proto3_test.hs for now.
+// Default is PACKED in this edition.
+// Test file-scope override.
 option features.field_presence = IMPLICIT;
-option features.enum_type = OPEN;
-option features.json_format = ALLOW;
-option features.utf8_validation = VERIFY;
+option features.repeated_field_encoding = EXPANDED;
 
 package editions2023;
 
@@ -23,7 +17,7 @@ message Foo {
   }
 
   message Sub {
-    int32 e = 1;
+    int32 e = 1 [features.field_presence = EXPLICIT];
   }
   Sub sub = 5;
 
@@ -36,6 +30,9 @@ message Foo {
   FooEnum enum = 6;
 
   repeated int32 f = 7;
+
+  // Test field-scope override.
+  repeated int32 g = 9 [features.repeated_field_encoding = PACKED];
 }
 
 message Strings {

--- a/proto-lens-tests/tests/editions2023_test.hs
+++ b/proto-lens-tests/tests/editions2023_test.hs
@@ -1,0 +1,139 @@
+-- Copyright 2024 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.ProtoLens
+import Lens.Family2 ((&), (.~), (^.))
+import qualified Data.ByteString.Builder as Builder
+import Proto.Editions2023
+    ( Foo
+    , Foo'FooEnum(..)
+    , Foo'Sub
+    , Strings
+    )
+import Proto.Editions2023_Fields
+    ( a
+    , b
+    , c
+    , d
+    , e
+    , f
+    , s
+    , sub
+    , maybe'c
+    , maybe'sub
+    , maybe's
+    , enum
+    , bytes
+    , string
+    )
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (testCase, (@=?), assertBool)
+
+import Data.ProtoLens.TestUtil
+
+main :: IO ()
+main = testMain
+  [ testGroup "Foo"
+    [ serializeTo "int32"
+        (defMessage & a .~ 150 :: Foo)
+        "a: 150"
+        $ tagged 1 $ VarInt 150
+    , serializeTo "repeated-string"
+        (defMessage & b .~ ["one", "two"] :: Foo)
+        (vcat $ map (keyedStr "b") ["one", "two"])
+        $ mconcat (map (tagged 2 . Lengthy) ["one", "two"])
+    , testGroup "oneof"
+        [ serializeTo "float"
+            -- Use denominators that aren't divisible by 2, to fill out the bits.
+            (defMessage & c .~ (20 / 3) :: Foo)
+            "c: 6.6666665"
+            $ tagged 3 $ Fixed32 0x40d55555
+        , serializeTo "bytes"
+            (defMessage & d .~ "a\0b" :: Foo)
+            "d: \"a\\000b\""
+            $ tagged 4 $ Lengthy "a\0b"
+        , serializeTo "overridden value"
+            (defMessage & d .~ "a\0b" & c .~ (20 / 3) :: Foo)
+            "c: 6.6666665"
+            $ tagged 3 $ Fixed32 0x40d55555
+        -- Scalar "oneof" fields should have a "maybe" selector.
+        , testCase "maybe" $ do
+            Nothing @=? (defMessage :: Foo) ^. maybe'c
+            Just 42 @=? ((defMessage :: Foo) & c .~ 42) ^. maybe'c
+            Nothing @=? (defMessage :: Foo) ^. maybe's
+        , testCase "message" $ do
+            Just 42 @=? ((defMessage :: Foo) & s .~ (defMessage :: Foo'Sub) & c .~ 42) ^. maybe'c
+            Nothing @=? ((defMessage :: Foo) & s .~ (defMessage :: Foo'Sub) & c .~ 42) ^. maybe's
+            17 @=? ((defMessage :: Foo) & s . e .~ 17) ^. s . e
+            let val = (defMessage :: Foo'Sub) & e .~ 17
+            Just val @=? ((defMessage :: Foo) & s .~ val) ^. maybe's
+        ]
+    -- Repeated scalar fields in proto3 should serialize as "packed" by default.
+    , serializeTo "packed-by-default"
+        (defMessage & f .~ [1,2,3] :: Foo)
+        (vcat [keyedInt "f" x | x <- [1..3]])
+        $ tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
+    , runTypedTest (roundTripTest "foo" :: TypedTest Foo)
+    ]
+  , testGroup "Strings"
+    [ deserializeFrom "bytes"
+        (Just $ defMessage & bytes .~ toStrictByteString invalidUtf8 :: Maybe Strings)
+        $ tagged 1 $ Lengthy invalidUtf8
+    , deserializeFrom "string"
+        (Nothing :: Maybe Strings)
+        $ tagged 2 $ Lengthy invalidUtf8
+    ]
+  -- Scalar field defaults are indistinguishable from unset fields.
+  , testGroup "defaulting"
+      [ testCase "int" $ (defMessage :: Foo) @=? (defMessage & a .~ 0)
+      , testCase "bytes" $ (defMessage :: Strings) @=? (defMessage & bytes .~ "")
+      , testCase "string" $ (defMessage :: Strings) @=? (defMessage & string .~ "")
+      , testCase "enum" $ (defMessage :: Foo) @=? (defMessage & enum .~ Foo'Enum1)
+      ]
+  -- Enums are sum types, except for aliases
+  , testGroup "enum"
+      [ testCase "aliases are exported" $ Foo'Enum2 @=? Foo'Enum2a
+      , serializeTo "serializeTo enum"
+          (defMessage & enum .~ Foo'Enum2 :: Foo)
+          "enum: Enum2"
+          $ tagged 6 $ VarInt 3
+      , serializeTo "serializeTo unrecognized"
+          (defMessage & enum .~ toEnum 9 :: Foo)
+          "enum: 9"
+          $ tagged 6 $ VarInt 9
+      , testCase "enum values" $ do
+          map toEnum [0, 3, 3] @=? [Foo'Enum1, Foo'Enum2, Foo'Enum2a]
+          fromEnum <$> (maybeToEnum 4 :: Maybe Foo'FooEnum) @=? Just 4
+          ["Foo'Enum1", "Foo'Enum2", "Foo'Enum2", "Foo'FooEnum'Unrecognized (Foo'FooEnum'UnrecognizedValue 5)"]
+              @=? map show [Foo'Enum1, Foo'Enum2, Foo'Enum2a, toEnum 5]
+          ["Enum1", "Enum2", "Enum2", "6"]
+              @=? map showEnum [Foo'Enum1, Foo'Enum2, Foo'Enum2a, toEnum 6]
+          [Just Foo'Enum1, Just Foo'Enum2, Just Foo'Enum2, maybeToEnum 4, maybeToEnum 5]
+              @=? map readEnum ["Enum1", "Enum2", "Enum2a", "4", "5"]
+      , testCase "enum patterns" $ do
+          assertBool "enum value" $ case toEnum 3 of
+                                      Foo'Enum2 -> True
+                                      _ -> False
+          assertBool "enum alias" $ case toEnum 3 of
+                                      Foo'Enum2a -> True
+                                      _ -> False
+
+      ]
+  -- Unset proto3 messages are different than the default value.
+  , testGroup "submessage"
+      [ testCase "Nothing" $ Nothing @=? ((defMessage :: Foo) ^. maybe'sub)
+      , testCase "Just" $ do
+          let val = (defMessage :: Foo'Sub) & e .~ 3
+          Just val @=? ((defMessage :: Foo) & sub .~ val) ^. maybe'sub
+      ]
+  ]
+
+
+invalidUtf8 :: Builder.Builder
+invalidUtf8 = Builder.word8 0xc3 <> Builder.word8 0x28

--- a/proto-lens-tests/tests/editions2023_test.hs
+++ b/proto-lens-tests/tests/editions2023_test.hs
@@ -23,9 +23,11 @@ import Proto.Editions2023_Fields
     , d
     , e
     , f
+    , g
     , s
     , sub
     , maybe'c
+    , maybe'e
     , maybe'sub
     , maybe's
     , enum
@@ -74,11 +76,14 @@ main = testMain
             let val = (defMessage :: Foo'Sub) & e .~ 17
             Just val @=? ((defMessage :: Foo) & s .~ val) ^. maybe's
         ]
-    -- Repeated scalar fields in proto3 should serialize as "packed" by default.
-    , serializeTo "packed-by-default"
+    , serializeTo "expanded-via-file-scope-override"
         (defMessage & f .~ [1,2,3] :: Foo)
         (vcat [keyedInt "f" x | x <- [1..3]])
-        $ tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
+        $ mconcat [tagged 7 $ VarInt x | x <- [1..3]]
+    , serializeTo "packed-via-field-scope-override"
+        (defMessage & g .~ [1,2,3] :: Foo)
+        (vcat [keyedInt "g" x | x <- [1..3]])
+        $ tagged 9 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
     , runTypedTest (roundTripTest "foo" :: TypedTest Foo)
     ]
   , testGroup "Strings"
@@ -89,12 +94,17 @@ main = testMain
         (Nothing :: Maybe Strings)
         $ tagged 2 $ Lengthy invalidUtf8
     ]
-  -- Scalar field defaults are indistinguishable from unset fields.
+  -- With field presence overridden to implicit,
+  -- scalar field defaults are indistinguishable from unset fields.
   , testGroup "defaulting"
       [ testCase "int" $ (defMessage :: Foo) @=? (defMessage & a .~ 0)
       , testCase "bytes" $ (defMessage :: Strings) @=? (defMessage & bytes .~ "")
       , testCase "string" $ (defMessage :: Strings) @=? (defMessage & string .~ "")
       , testCase "enum" $ (defMessage :: Foo) @=? (defMessage & enum .~ Foo'Enum1)
+      ]
+  , testGroup "explicit"
+      [ testCase "set" $ (defMessage & e .~ 0 :: Foo'Sub) ^. maybe'e @=? Just 0
+      , testCase "unset" $ (defMessage :: Foo'Sub) ^. maybe'e @=? Nothing
       ]
   -- Enums are sum types, except for aliases
   , testGroup "enum"


### PR DESCRIPTION
* Informs `protoc` that it supports Protobuf Editions up to edition 2023.
* Implements feature resolution.
* Controls behavior through features.  Behaviors adjusted through syntax type have been updated to use the feature sets equivalent to proto2 or proto3.

This needs a recent `prococ` which supports Protobuf Editions.  I do not know which version would actually be the least working one, but at least I know that 28.0 works.